### PR TITLE
Add missing <meta charset="utf-8" /> to HTML files

### DIFF
--- a/attribution.html
+++ b/attribution.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
+    <meta charset="utf-8" />
     <title>Wikimedia Discovery timeline attribution</title>
     <meta name="description" content="Attribution for the timeline of events surrounding the Wikimedia Discovery project">
     <meta name="author" content="Molly White">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="no-js">
   <head>
+    <meta charset="utf-8" />
     <title>Wikimedia timeline of recent events</title>
     <meta name="description" content="A timeline of recent events surrounding the Wikimedia projects">
     <meta name="author" content="Molly White">


### PR DESCRIPTION
Without this, browser might try to use a different encoding for the page,
and links such as https://commons.wikimedia.org/wiki/File:María_Sefidari.JPG
(with the 'í') point to wrong places.

This way you should also be able to write `María` instead of `Mar&iacute;a`
and `Möller` instead of `M&ouml;ller`, but I didn't change them all.
