### PR TITLE
Add permalinks to <h2> elements.

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -187,6 +187,18 @@ footer.page-footer a {
   line-height: 110%;
 }
 
+.timeline-description h2 a {
+  text-decoration: inherit;
+  color: inherit;
+  float: right;
+  visibility: hidden;
+}
+
+.timeline-description h2:hover a {
+  visibility: visible;
+  opacity: 0.5;
+}
+
 .timeline-description h2,
 .timeline-description ul {
   margin: 5px 0;

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-05-01">May 1, 2014</time></span>
-            <h2>Lila Tretikov announced as Executive Director</h2>
+            <h2><a id="1" href="#1"><i class="fa fa-link"></i></a>Lila Tretikov announced as Executive Director</h2>
             <div class="captioned-image image-right">
               <a href="https://commons.wikimedia.org/wiki/File:Lila_Tretikov_April_2014_(5)_crop.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/0a/Lila_Tretikov_April_2014_%285%29_crop.jpg/196px-Lila_Tretikov_April_2014_%285%29_crop.jpg" alt="Staff portrait of Lila Tretikov" />
@@ -70,7 +70,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-08-06">August 6, 2014</time></span>
-            <h2>Media Viewer and superprotect conflict</h2>
+            <h2><a id="2" href="#2"><i class="fa fa-link"></i></a>Media Viewer and superprotect conflict</h2>
             <p>The Wikimedia Foundation roll out the <a href="https://en.wikipedia.org/wiki/Wikipedia:Media_Viewer">Media Viewer</a>, a software feature intended to provide a "more immersive multimedia experience". Following a <a href="https://en.wikipedia.org/w/index.php?title=Wikipedia:Media_Viewer/June_2014_RfC&oldid=616205396">community decision</a>, a volunteer administrator disables the feature. He is reverted by a Wikimedia Foundation staff member, who <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2014-August/073767.html">threatens</a> to remove his administrator status. Soon after, the Wikimedia Foundation rolls out a <a href="https://en.wikipedia.org/wiki/Wikipedia:Protection_policy#Superprotect">software change called "superprotect"</a> that can restrict anyone but WMF employees from changing a page. These events result in an <a href="https://en.wikipedia.org/wiki/Wikipedia:Arbitration/Requests/Case/Media_Viewer_RfC">arbitration case</a> on the English Wikipedia, as well as <a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2014-08-13/News_and_notes">controversy on the German Wikipedia</a>. The superprotect feature is eventually removed from all wikis on November 5, 2015.</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2014-07-09/News_and_notes"><i>Signpost</i>: Echoes of the past haunt new conflict over tech initiative</a></li>
@@ -86,7 +86,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-08-19">August 19, 2014</time></span>
-            <h2>Letter to Wikimedia Foundation: Superprotect and Media Viewer</h2>
+            <h2><a id="3" href="#3"><i class="fa fa-link"></i></a>Letter to Wikimedia Foundation: Superprotect and Media Viewer</h2>
             <p><a href="https://en.wikipedia.org/wiki/User:Peteforsyth">Pete Forsyth</a>, a Wikimedia community member, writes a <a href="https://meta.wikimedia.org/wiki/Letter_to_Wikimedia_Foundation:_Superprotect_and_Media_Viewer">letter</a> to the Wikimedia Foundation leadership expressing concern about the recent events with the Media Viewer rollout and the superprotect change. The letter receives nearly 1,000 signatures, but receives no response from the Wikimedia Foundation.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Letter_to_Wikimedia_Foundation:_Superprotect_and_Media_Viewer">Meta: Letter to Wikimedia Foundation: Superprotect and Media Viewer</a></li>
@@ -100,7 +100,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-08-20">August 20, 2014</time></span>
-            <h2>Jan-Bart de Vreede writes a post about "crossroads"</h2>
+            <h2><a id="4" href="#4"><i class="fa fa-link"></i></a>Jan-Bart de Vreede writes a post about "crossroads"</h2>
             <p>Jan-Bart de Vreede, then the chair of the Wikimedia Board of Trustees, <a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=9585319#Our_Future_and_the_role_of_the_Foundation">posts on Lila Tretikov's Meta talk page</a> that "we are at a crossroads....Other internet projects (not limiting ourselves to websites) are passing us by left and right...All of this is going to require change, change that might not be acceptable to some of you. I hope that all of you will  be a part of this next step in our evolution. But I understand that if you decide to take a wiki-break, that might be the way things have to be. Even so, you have to let the Foundation do its work and allow us all to take that next step when needed. I can only hope that your break is temporary, and that you will return when the time is right."</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=9585319#Our_Future_and_the_role_of_the_Foundation">Jan-Bart de Vreede's post on Meta:User talk:LilaTretikov (WMF)</a></li>
@@ -114,7 +114,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-09-19">September 19, 2014</time></span>
-            <h2>Jessie Wild leaves</h2>
+            <h2><a id="5" href="#5"><i class="fa fa-link"></i></a>Jessie Wild leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://wikimediafoundation.org/wiki/File:Jessie_Wild_008_-_Wikimedia_Foundation_Oct11.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/81/Jessie_Wild_008_-_Wikimedia_Foundation_Oct11.jpg/320px-Jessie_Wild_008_-_Wikimedia_Foundation_Oct11.jpg" alt="Staff portrait of Jessie Wild" />
@@ -131,7 +131,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-09-29">September 29, 2014</time></span>
-            <h2>Steven Walling leaves</h2>
+            <h2><a id="6" href="#6"><i class="fa fa-link"></i></a>Steven Walling leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Steven_Walling_016.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Steven_Walling_016.jpg/320px-Steven_Walling_016.jpg" alt="Staff portrait of Steven Walling" />
@@ -148,7 +148,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-09-30">September 30, 2014</time></span>
-            <h2>Sumana Harihareswara leaves</h2>
+            <h2><a id="7" href="#7"><i class="fa fa-link"></i></a>Sumana Harihareswara leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Sumana_Harihareswara_021_-_Berlin_2011.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/9/92/Sumana_Harihareswara_021_-_Berlin_2011.jpg/320px-Sumana_Harihareswara_021_-_Berlin_2011.jpg"  alt="Staff portrait of Sumana Harihareswara" />
@@ -169,7 +169,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-09-29">October 29, 2014</time></span>
-            <h2>Damon Sicore joins as Vice President of Engineering</h2>
+            <h2><a id="8" href="#8"><i class="fa fa-link"></i></a>Damon Sicore joins as Vice President of Engineering</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Sicore,_Damon_2014.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Sicore%2C_Damon_2014.jpg" alt="Staff portrait of Damon Sicore" />
@@ -189,7 +189,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2014-11-21">November 21, 2014</time></span>
-            <h2>Brandon Harris leaves</h2>
+            <h2><a id="9" href="#9"><i class="fa fa-link"></i></a>Brandon Harris leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Brandon_Harris-9992-2.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Brandon_Harris-9992-2.jpg/320px-Brandon_Harris-9992-2.jpg" alt="Staff portrait of Brandon Harris" />
@@ -206,7 +206,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-01-12">January 12, 2015</time></span>
-            <h2>Lila Tretikov discusses her "Call to Action" with the Board of Trustees</h2>
+            <h2><a id="10" href="#10"><i class="fa fa-link"></i></a>Lila Tretikov discusses her "Call to Action" with the Board of Trustees</h2>
             <p>The "<a href="https://meta.wikimedia.org/wiki/Communications/State_of_the_Wikimedia_Foundation#2015_Call_to_Action">Call to Action</a>" is discussed with the Board of Trustees and other attendees. This is a list of focuses for the Wikimedia Foundation, and one of the first clear statements of Lila Tretikov's vision. <a href="https://wikimediafoundation.org/wiki/Minutes/2015-01-12">Meeting notes</a> indicate she intends to present it to staff at the upcoming all-hands meeting on Jan 21&ndash;22.</p>
             <ul>
               <li><a href="https://wikimediafoundation.org/wiki/Minutes/2015-01-12">Minutes from January 12, 2015 board meeting</a></li>
@@ -220,7 +220,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-02-19">February 19, 2015</time></span>
-            <h2>Community Engagement team is created as Anasuya Sengupta's departure is announced</h2>
+            <h2><a id="11" href="#11"><i class="fa fa-link"></i></a>Community Engagement team is created as Anasuya Sengupta's departure is announced</h2>
             <p>Community Engagement team is created in response to Anasuya Sengupta's upcoming departure. The team is led by Luis Villa, who is promoted to Senior Director of Community Engagement. Siko Bouterse is promoted to Director of Community Resources to lead the Grantmaking team.</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2015-February/076853.html">Announcement:A new structure for WMF Community Engagement</a></li>
@@ -235,7 +235,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-02-23">February 23, 2015</time></span>
-            <h2>The Wikimedia Foundation asks for strategy input from the community</h2>
+            <h2><a id="12" href="#12"><i class="fa fa-link"></i></a>The Wikimedia Foundation asks for strategy input from the community</h2>
             <p>The Wikimedia Foundation asks community members to provide input on the "future of Wikimedia" to "inform the development of the direction and priorities for the Wikimedia Foundation". This takes the form of a two-week-long <a href="https://meta.wikimedia.org/wiki/2015_Strategy/Community_consultation">community consultation</a>, announced by Philippe Beaudette. The consultation contains only two questions. Although it as identified as "the first step" in the consultation, it is never revisited.</p>
             <ul>
               <li><a href="https://blog.wikimedia.org/2015/02/23/strategy-consultation/">Wikimedia blog: Join the Wikimedia strategy consultation</a></li>
@@ -250,7 +250,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-03-18">March 18, 2015</time></span>
-            <h2>Gayle Karen Young leaves</h2>
+            <h2><a id="13" href="#13"><i class="fa fa-link"></i></a>Gayle Karen Young leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Young,_Gayle_September_2014.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/55/Young%2C_Gayle_September_2014.jpg/320px-Young%2C_Gayle_September_2014.jpg" alt="Staff portrait of Gayle Karen Young" />
@@ -278,7 +278,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-03-18">March 18, 2015</time></span>
-            <h2>Anasuya Sengupta leaves</h2>
+            <h2><a id="14" href="#14"><i class="fa fa-link"></i></a>Anasuya Sengupta leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Anasuya_Sengupta_March_2013.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Anasuya_Sengupta_March_2013.jpg/320px-Anasuya_Sengupta_March_2013.jpg" alt="Staff portrait of Anasuya Sengupta" />
@@ -298,7 +298,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-03-18">March 18, 2015</time></span>
-            <h2>Terry Gilbey joins as interim COO</h2>
+            <h2><a id="15" href="#15"><i class="fa fa-link"></i></a>Terry Gilbey joins as interim COO</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Gilbey,_Terence_March_2015.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Gilbey%2C_Terence_March_2015.jpg/320px-Gilbey%2C_Terence_March_2015.jpg" alt="Staff portrait of Terry Gilbey" />
@@ -326,7 +326,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-03-27">March 27, 2015</time></span>
-            <h2>Kourosh Karimkhany joins as Vice President of Strategic Partnerships</h2>
+            <h2><a id="16" href="#16"><i class="fa fa-link"></i></a>Kourosh Karimkhany joins as Vice President of Strategic Partnerships</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Kourosh_Karimkhany-_March_2015.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Kourosh_Karimkhany-_March_2015.jpg/320px-Kourosh_Karimkhany-_March_2015.jpg" alt="Staff portrait of Kourosh Karimkhany" />
@@ -347,7 +347,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-02">April 2, 2015</time></span>
-            <h2>First publication of Wikimedia Foundation's "Call to Action" to the broader community</h2>
+            <h2><a id="17" href="#17"><i class="fa fa-link"></i></a>First publication of Wikimedia Foundation's "Call to Action" to the broader community</h2>
             <p>The "<a href="https://meta.wikimedia.org/wiki/Communications/State_of_the_Wikimedia_Foundation#2015_Call_to_Action">Call to Action</a>" is first outlined publicly. The list is divided into subcategories: Improve technology &amp; execution, focus on knowledge &amp; community, support innovation &amp; new knowledge.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Communications/State_of_the_Wikimedia_Foundation#2015_Call_to_Action">"Call to Action" section in the 2015 State of the Wikimedia Foundation document</a></li>
@@ -361,7 +361,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-02">April 2, 2015</time> <span class="note">(not public until <time datetime="2016-02-10">February 10, 2016</time> <i>Signpost</i> article)</span></span>
-            <h2>Earliest document presented to the Knight Foundation</h2>
+            <h2><a id="18" href="#18"><i class="fa fa-link"></i></a>Earliest document presented to the Knight Foundation</h2>
             <p>The Wikimedia Foundation finishes a document to present to the Knight Foundation as the motivation for a grant to support the search and discovery efforts.</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-10/Special_report"><i>Signpost</i>: New internal documents raise questions about the origins of the Knowledge Engine</a></li>
@@ -375,7 +375,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-13">April 13, 2015</time></span>
-            <h2>Erik M&ouml;ller leaves</h2>
+            <h2><a id="19" href="#19"><i class="fa fa-link"></i></a>Erik M&ouml;ller leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Moeller,_Erik_November_2014.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Moeller%2C_Erik_November_2014.jpg/320px-Moeller%2C_Erik_November_2014.jpg" alt="Staff portrait of Erik M&ouml;ller" />
@@ -397,7 +397,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-16">April 16, 2015</time></span>
-            <h2>Howie Fung leaves</h2>
+            <h2><a id="20" href="#20"><i class="fa fa-link"></i></a>Howie Fung leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://meta.wikimedia.org/wiki/File:HFung_April_2010_wikimedia_03_10_841.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/HFung_April_2010_wikimedia_03_10_841.jpg/320px-HFung_April_2010_wikimedia_03_10_841.jpg" alt="Staff portrait of Howie Fung" />
@@ -407,7 +407,7 @@
             <p>Howie Fung, Director of Product Development, leaves the Wikimedia Foundation after five and a half years of employment.</p>
               
             <div class="sub-entry">
-              <h2>Maryana Pinchuk leaves</h2>
+              <h2><a id="21" href="#21"><i class="fa fa-link"></i></a>Maryana Pinchuk leaves</h2>
               <div class="captioned-image image-right landscape">
                 <a href="https://commons.wikimedia.org/wiki/File:Maryana_Pinchuk_007_-_Wikimedia_Foundation_Oct11.jpg">
                   <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Maryana_Pinchuk_007_-_Wikimedia_Foundation_Oct11.jpg/320px-Maryana_Pinchuk_007_-_Wikimedia_Foundation_Oct11.jpg" alt="Staff portrait of Maryana Pinchuk" />
@@ -425,7 +425,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-21">April 21, 2015</time></span>
-            <h2>Wikimedia Foundation reorganizes its engineering team</h2>
+            <h2><a id="22" href="#22"><i class="fa fa-link"></i></a>Wikimedia Foundation reorganizes its engineering team</h2>
             <p>The Wikimedia Foundation reorganizes its engineering team. Some of the April departures are suspected to be in relation to this shakeup. The reorganization is later described as poorly handled, and it is criticized for being based on assumptions of an impractically large budget increase. The reorganization occurred in a span of two weeks, and some WMF staff did not learn about it until the day it was implemented.</p>
           </div>
         </div>
@@ -436,7 +436,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-24">April 24, 2015</time></span>
-            <h2>Jared Zimmerman leaves</h2>
+            <h2><a id="23" href="#23"><i class="fa fa-link"></i></a>Jared Zimmerman leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Zimmerman,_Jared_June_2013.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/Zimmerman%2C_Jared_June_2013.jpg/320px-Zimmerman%2C_Jared_June_2013.jpg" alt="Staff portrait of Jared Zimmerman" />
@@ -453,7 +453,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-04-30">April 30, 2015</time></span>
-            <h2>Wes Moran joins as Vice President of Search &amp; Discovery</h2>
+            <h2><a id="24" href="#24"><i class="fa fa-link"></i></a>Wes Moran joins as Vice President of Search &amp; Discovery</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Moran,_Wes_April_2015.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/dc/Moran%2C_Wes_April_2015.jpg/320px-Moran%2C_Wes_April_2015.jpg" alt="Staff portrait of Wes Moran" />
@@ -470,7 +470,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-05-30">May 30, 2015</time></span>
-            <h2>Funds Dissemination Committee member asks about the focus on the Search and Discovery team</h2>
+            <h2><a id="25" href="#25"><i class="fa fa-link"></i></a>Funds Dissemination Committee member asks about the focus on the Search and Discovery team</h2>
             <p><a href="https://meta.wikimedia.org/wiki/User:Risker">User:Risker</a>, a member of the Funds Dissemination Committee, <a href="https://meta.wikimedia.org/w/index.php?title=Talk:Wikimedia_Foundation_Annual_Plan/2015-16/draft&oldid=12681712#Review_from_current_FDC_member">posts a "Review from current FDC member"</a> on the draft 2015&ndash;2016 Wikimedia Foundation Annual Plan talk page. She includes the comment, "Search and Discovery, a new team, seems to be extraordinarily well-staffed with a disproportionate number of engineers at the same time as other areas seem to be wanting for them. I don't see "fix search" in the <a href="https://meta.wikimedia.org/wiki/Communications/State_of_the_Wikimedia_Foundation#2015_Call_to_Action">Call to Action</a> document; even if it fell into the heading "Improve technology and execution", this seems like an abnormally large concentration of the top WMF Engineering minds to be focusing on a topic that didn't even rate its own mention in the CtA. More explanation of why Search and Discovery has suddenly become such a major focus is required to assess whether this is appropriate resourcing."</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=Talk:Wikimedia_Foundation_Annual_Plan/2015-16/draft&oldid=12681712#Review_from_current_FDC_member">Meta: Talk:Wikimedia Foundation Annual Plan/2015-16/draft#Review from current FDC member</a></li>
@@ -484,7 +484,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-06-05">June 5, 2015</time></span>
-            <h2>2015 Wikimedia Foundation Board of Trustees election results announced</h2>
+            <h2><a id="26" href="#26"><i class="fa fa-link"></i></a>2015 Wikimedia Foundation Board of Trustees election results announced</h2>
             <p>Dariusz Jemielniak (<a href="https://meta.wikimedia.org/wiki/User:Pundit">User:Pundit</a>), James Heilman (<a href="https://meta.wikimedia.org/wiki/User:Doc_James">User:Doc James</a>), and Denny Vrande&#269;i;&#263; (<a href="https://meta.wikimedia.org/wiki/User:Denny">User:Denny</a>) are elected to the three two-year-long community seats on the Wikimedia Foundation's <a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation_Board_of_Trustees">Board of Trustees</a>.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation_elections/Board_elections/2015">2015 elections to the Board of Trustees</a></li>
@@ -498,7 +498,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-06-11">June 11, 2015</time></span>
-            <h2>"Knowledge engine" terminology first used publicly</h2>
+            <h2><a id="27" href="#27"><i class="fa fa-link"></i></a>"Knowledge engine" terminology first used publicly</h2>
             <p>The term "knowledge engine" is first used publicly in <a href="https://commons.wikimedia.org/w/index.php?title=File%3AWMF_Strategy_Preview%2C_WMF_Metrics_Meeting_June_2015.pdf&page=50">a slide</a> in the June 2015 <a href="https://meta.wikimedia.org/wiki/WMF_Metrics_and_activities_meetings">Metrics meeting</a>. Following a slide reading "Strategic Direction" is a slide reading "From Wikipedia and sisters &rarr; Open Source library of all Knowledge. A knowledge engine where users, institutions and computers around the world contribute and discover knowledge on Wikimedia every day, on every platform, in their own language."</p>
             <ul>
               <li><a href="https://commons.wikimedia.org/w/index.php?title=File%3AWMF_Strategy_Preview%2C_WMF_Metrics_Meeting_June_2015.pdf">June 2015 Strategy Preview slides</a></li>
@@ -513,7 +513,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-06-16">June 16, 2015</time></span>
-            <h2>Damon Sicore leaves</h2>
+            <h2><a id="28" href="#28"><i class="fa fa-link"></i></a>Damon Sicore leaves</h2>
             <p>Damon Sicore, Vice President of Engineering, leaves the Wikimedia Foundation after eight months of employment. This is first brought to light when <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2015-June/078283.html">someone notices his account has been removed from the Foundation wiki and globally locked</a>. Some Wikimedia Foundation staff clarify that Sicore is on leave for two weeks, though they have been instructed not to share this information in writing. Lila Tretikov subsequently <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2015-July/078460.html">reveals</a> that Sicore will not be returning. Reasons for his departure are not provided; in an FAQ attached to her email, Lila states that "Damon's departure is a personnel issue, so we are not able to comment on it."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2015-June/078283.html">Tomasz W. Koz&#322;owski notices Sicore's account has been locked and asks about it on <i>Wikimedia-l</i></a></li>
@@ -529,7 +529,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-06-30">June 30, 2015</time></span>
-            <h2>Presentation to the Board features the "Knowledge Engine" terminology</h2>
+            <h2><a id="29" href="#29"><i class="fa fa-link"></i></a>Presentation to the Board features the "Knowledge Engine" terminology</h2>
             <div class="captioned-image image-right landscape">
               <a href="http://wittylama.com/2016/02/15/knowledge-engine-by-wikipedia/">
                 <img src="https://wittylama.files.wordpress.com/2016/02/12722459_10156577059655241_1851331260_o.jpg?w=1280" alt="Opening slide to a presentation. Text reads 'Knowledge Engine', underneath is a vector graphic of a rocket." />
@@ -549,7 +549,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-07-24">July 24, 2015</time></span>
-            <h2>Kourosh Karimkhany leaves</h2>
+            <h2><a id="30" href="#30"><i class="fa fa-link"></i></a>Kourosh Karimkhany leaves</h2>
             <p>Kourosh Karimkhany, Vice President of Strategic Partnerships, leaves the Wikimedia Foundation after four months of employment.</p>
           </div>
         </div>
@@ -560,7 +560,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-07-30">July 30, 2015</time></span>
-            <h2>James Douglas and Nik Everett leave</h2>
+            <h2><a id="31" href="#31"><i class="fa fa-link"></i></a>James Douglas and Nik Everett leave</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://wikimediafoundation.org/wiki/File:Douglas,_James_November_2014.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/8/89/Douglas%2C_James_November_2014.jpg" alt="Staff portrait of James Douglas" />
@@ -583,7 +583,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-09-02">September 2, 2015</time></span>
-            <h2>Vibha Bamba leaves</h2>
+            <h2><a id="32" href="#32"><i class="fa fa-link"></i></a>Vibha Bamba leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Bamba,_Vibha_Feb_2014.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/7/73/Bamba%2C_Vibha_Feb_2014.jpg" alt="Staff portrait of Vibha Bamba" />
@@ -600,7 +600,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-09-14">September 14, 2015</time></span>
-            <h2>Boryana Dineva joins</h2>
+            <h2><a id="33" href="#33"><i class="fa fa-link"></i></a>Boryana Dineva joins</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Dineva,_Boryana_September_2015.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4b/Dineva%2C_Boryana_September_2015.jpg/320px-Dineva%2C_Boryana_September_2015.jpg" alt="Staff portrait of Boryana Dineva" />
@@ -620,7 +620,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-09-15">September 15, 2015</time></span>
-            <h2>Philippe Beaudette leaves</h2>
+            <h2><a id="34" href="#34"><i class="fa fa-link"></i></a>Philippe Beaudette leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Beaudette,_Philippe_4.11.2013.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Beaudette%2C_Philippe_4.11.2013.jpg/320px-Beaudette%2C_Philippe_4.11.2013.jpg" alt="Staff portrait of Philippe Beaudette" />
@@ -640,7 +640,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-09-18">September 18, 2015</time> <span class="note">(grant agreement document not public until <time datetime="2016-02-11">February 11, 2016</time>)</span></span>
-            <h2>Knight Foundation approves $250,000 grant to build a search engine</h2>
+            <h2><a id="35" href="#35"><i class="fa fa-link"></i></a>Knight Foundation approves $250,000 grant to build a search engine</h2>
             <p>The Knight Foundation approves a $250,000 grant to the Wikimedia Foundation, under the conditions that the money is used "to advance new models for finding information by supporting stage one development of the Knowledge Engine by Wikipedia, a system for discovering reliable and trustworthy public information on the Internet." The document titles the project "Search Engine by Wikipedia." The document details how the Knowledge Engine will "upend" commercial search engine structures. It cites development on similar projects from Google, Yahoo, and other "big commercial search engines" as a potential threat to the project.</p>
             <ul>
               <li><a href="https://wikimediafoundation.org/wiki/File:Knowledge_engine_grant_agreement.pdf">Knowledge Engine grant agreement</a></li>
@@ -655,7 +655,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-09-30">September 30, 2015</time></span>
-            <h2>Garfield Byrd leaves</h2>
+            <h2><a id="36" href="#36"><i class="fa fa-link"></i></a>Garfield Byrd leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Garfield_Byrd_003_-_Wikimedia_Foundation_Oct11.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Garfield_Byrd_003_-_Wikimedia_Foundation_Oct11.jpg/320px-Garfield_Byrd_003_-_Wikimedia_Foundation_Oct11.jpg" alt="Staff portrait of Garfield Byrd" />
@@ -676,7 +676,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-10-07">October 7, 2015</time> <span class="note">(email not public until <time datetime="2016-02-03">February 3, 2016</time>)</span></span>
-            <h2>James Heilman sends email to the rest of the Board of Trustees with concerns about the Knight Foundation grant</h2>
+            <h2><a id="37" href="#37"><i class="fa fa-link"></i></a>James Heilman sends email to the rest of the Board of Trustees with concerns about the Knight Foundation grant</h2>
             <p>After the grant is presented to the Wikimedia Foundation Board of Trustees, board member James Heilman writes an email to the rest of the board. In this email, he states, "We are at 6 days since being notified of the Knight Foundation grant. I at this point strongly oppose its acceptance. There are too many issues..." He goes on to detail his concerns, including that the WMF is "'selling' the Knight Foundation a search engine," confusion over whether or not the project will involve building a search engine, and "serious lack of transparency." He warns "it maybe a bigger issue than simply refusing a grant."</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-03/In_focus"><i>Signpost</i>: The Knight Foundation grant: a timeline and an email to the board</a></li>
@@ -691,7 +691,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-10-09">October 9, 2015</time></span>
-            <h2>Wes Moran becomes Vice President of Product</h2>
+            <h2><a id="38" href="#38"><i class="fa fa-link"></i></a>Wes Moran becomes Vice President of Product</h2>
             <p>Wes Moran, formerly the Vice President of Search &amp; Discovery, is retitled the Vice President of Product.</p>
           </div>
         </div>
@@ -702,14 +702,14 @@
           </div>
           <div class="timeline-description float-left">
             <span class="timestamp"><time datetime="2015-11-04">November 4, 2015</time> <span class="note">(not public until <time datetime="2016-02-10">February 10, 2016</time> <i>Signpost</i> article)</span></span>
-            <h2>Lila Tretikov sends email to staff saying that the Knowledge Engine "is NOT ... a search engine"</h2>
+            <h2><a id="39" href="#39"><i class="fa fa-link"></i></a>Lila Tretikov sends email to staff saying that the Knowledge Engine "is NOT ... a search engine"</h2>
             <p>Lila Tretikov sends an email to staff, in which she states "[the Knowledge Engine] is NOT ... a search engine". This email is later provided to the <i>Signpost</i> by several staff members.</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-10/Special_report"><i>Signpost</i>: New internal documents raise questions about the origins of the Knowledge Engine</a></li>
             </ul>
 
             <div class="sub-entry">
-              <h2>Wikimedia Discovery FAQ page created</h2>
+              <h2><a id="40" href="#40"><i class="fa fa-link"></i></a>Wikimedia Discovery FAQ page created</h2>
               <p><a href="https://wikimediafoundation.org/wiki/User:Tfinc">Tomasz Finc</a> creates the <a href="https://www.mediawiki.org/wiki/Wikimedia_Discovery/FAQ">Wikimedia Discovery FAQ</a> page on MediaWiki wiki. In its first draft, it includes the question "Are you building a new search engine?"</p>
               <ul>
                 <li><a href="https://www.mediawiki.org/wiki/Wikimedia_Discovery/FAQ">Wikimedia Discovery FAQ</a></li>
@@ -724,7 +724,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-05">November 5, 2015</time></span>
-            <h2>Terry Gilbey leaves</h2>
+            <h2><a id="41" href="#41"><i class="fa fa-link"></i></a>Terry Gilbey leaves</h2>
             <p>Terry Gilbey, interim Chief Operating Officer, leaves the Wikimedia Foundation after eight months of employment.</p>
           </div>
         </div>
@@ -735,7 +735,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-05">November 5, 2015</time></span>
-            <h2>Superprotect feature is removed from all wikis</h2>
+            <h2><a id="42" href="#42"><i class="fa fa-link"></i></a>Superprotect feature is removed from all wikis</h2>
             <p>The Wikimedia Foundation removes the superprotect feature from all wikis. Lila Tretikov explains, "Superprotect set up a precedent of mistrust, and this is something it was really important for us to remove, to at least come back to the baseline of a relationship where we're working together, we're one community, to create a better process. To make sure we can move together faster, and to make sure everybody is part of that process, everybody is part of that conversation, and not just us at the Wikimedia Foundation." This change is rushed out in order to be presented at the Metrics meeting. Some Wikimedia community members involved in the August 2014 letter to the Wikimedia Foundation <a href="https://meta.wikimedia.org/wiki/Talk:Letter_to_Wikimedia_Foundation:_Superprotect_and_Media_Viewer#November_2015_poll:_Has_the_letter_achieved_its_goal.3F">express concern</a> that the underlying problem has not been addressed.</p>
             <ul>
               <li><a href="https://www.youtube.com/watch?v=ePV-7nhO-z0#t=18m50s">Lila explains removal of superprotect at the WMF Metrics and Activities Meeting</a></li>
@@ -751,7 +751,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-07">November 7, 2015</time> <span class="note">(not public until <time datetime="2016-02-03">February 3, 2016</time>)</span></span>
-            <h2>Board of Trustees approves Knight Foundation grant</h2>
+            <h2><a id="43" href="#43"><i class="fa fa-link"></i></a>Board of Trustees approves Knight Foundation grant</h2>
             <p>The Board of Trustees approves the $250,000 grant from the Knight Foundation. Although Heilman supports the vote, he later <a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-03/In_focus">states</a> that he did so "following pressure which included comments about potentially removing members of the Board."
             <ul>
               <li><a href="https://wikimediafoundation.org/wiki/Minutes/2015-11-07">Wikimedia Foundation wiki: Board minutes from November 7, 2015</a></li>
@@ -766,7 +766,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-09">November 9, 2015</time></span>
-            <h2>Wikimedia Foundation all-staff meeting with Lila Tretikov, Jimmy Wales, and Patricio Lorente</h2>
+            <h2><a id="44" href="#44"><i class="fa fa-link"></i></a>Wikimedia Foundation all-staff meeting with Lila Tretikov, Jimmy Wales, and Patricio Lorente</h2>
             <p>Lila Tretikov calls an all-staff meeting with herself and board representatives to discuss growing staff discontent at the Foundation's senior leadership and to provide an opportunity for open staff feedback. This meeting establishes that the board has provided Lila with a second chance and offered her their full support. Although the resulting airing of grievances is cathartic for some, many WMF employees are left frustrated by the lack of agenda and established outcomes from the meeting and are disheartened by the stream of frustrated and negative feedback. One staff member characterizes the two-hour meeting as "a combination of a guilt trip and a trial, with no set goals."</p>
           </div>
         </div>
@@ -777,7 +777,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-18">November 18, 2015</time></span>
-            <h2>Patricio Lorente sends email to Wikimedia Foundation staff</h2>
+            <h2><a id="45" href="#45"><i class="fa fa-link"></i></a>Patricio Lorente sends email to Wikimedia Foundation staff</h2>
             <p>Wikimedia Foundation Board of Trustees chair Patricio Lorente sends an email to Wikimedia Foundation staff, referencing concerns and a statement on the internal wiki. The email goes on to state, "We recognize there were legitimate concerns in certain areas, such as staff management, communications, and style of leadership. We acknowledge that many of those issues arise also from poor communication from the Board in setting expectations for change and the asks we have made to Lila, our Executive Director. We are working with Lila to put together a plan to address these issues. We are confident that she has the capability and the commitment needed for this challenging time, and we know that, at the present time, she is listening carefully to the Board, to you, and to the community. To that end, the Board remains unanimously committed in our support of Lila in her role and in her efforts to adapt her leadership and to address these issues. We ask everyone to move forward. We will continue working with the Executive Director and supporting her progress, and we rely on your help in this process and your personal commitment to the WMF and our shared vision."</p>
           </div>
         </div>
@@ -788,7 +788,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-22">November 22, 2015</time></span>
-            <h2>Steve Scheier joins as coach to Lila Tretikov</h2>
+            <h2><a id="46" href="#46"><i class="fa fa-link"></i></a>Steve Scheier joins as coach to Lila Tretikov</h2>
             <p>Steve Scheier, a non-profit consultant, is announced to "help with leadership challenges" specifically including "coaching of Lila."</p>
           </div>
         </div>
@@ -799,7 +799,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-11-23">November 23, 2015</time></span>
-            <h2>Funds Dissemination Committee criticizes lack of transparency from the Wikimedia Foundation</h2>
+            <h2><a id="47" href="#47"><i class="fa fa-link"></i></a>Funds Dissemination Committee criticizes lack of transparency from the Wikimedia Foundation</h2>
             <p>The Funds Dissemination Committee include in their recommendations a request that the Wikimedia Foundation "improve its own level of planning transparency and budget detail." They state that they are "appalled by the closed way that the WMF has undertaken both strategic and annual planning, and the WMF's approach to budget transparency (or lack thereof). This sets a poor example for the affiliate organisations in the movement, decreases the moral authority of the FDC and decreases the general level of trust within the movement." They recommend that the Wikimedia Foundation submit their annual plan for review in the second round of the process.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Grants:APG/FDC_recommendations/2015-2016_round_1#WMF">FDC recommendations for the Wikimedia Foundation</a></li>
@@ -813,7 +813,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-12-08">December 8, 2015</time> <span class="note">(leaked to the Signpost and discussed, but not made fully public, on <time datetime="2016-01-06">January 6, 2016</time>)</span></span>
-            <h2>Staff engagement survey results announced internally to staff</h2>
+            <h2><a id="48" href="#48"><i class="fa fa-link"></i></a>Staff engagement survey results announced internally to staff</h2>
             <p>The results of a staff engagement survey are announced internally. Although more than two dozen Wikimedia Foundation staff members supported releasing the survey results publicly, this has not happened. A staff member leaked the survey results to the <i>Signpost</i>, which <a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-01-06/News_and_notes">provided a summary but did not publish the results in full</a>. Among the findings, gleaned from 93% of staff members, were high levels of pride in working at the Wikimedia Foundation and strong confidence in line managers. More concerning were responses to other questions regarding the Foundation's senior leadership:</p>
             <ul>
               <li>Senior leadership at Wikimedia have communicated a vision that motivates me: 7% agree</li>
@@ -834,7 +834,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-12-28">December 28, 2015</time></span>
-            <h2>James Heilman is removed from the Board of Trustees</h2>
+            <h2><a id="49" href="#49"><i class="fa fa-link"></i></a>James Heilman is removed from the Board of Trustees</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Dr._James_Heilman.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/de/Dr._James_Heilman.jpg/320px-Dr._James_Heilman.jpg" alt="Portrait of James Heilman" />
@@ -856,7 +856,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-12-31">December 31, 2015</time></span>
-            <h2>Jan-Bart de Vreede and Stu West finish their terms on the Board of Trustees</h2>
+            <h2><a id="50" href="#50"><i class="fa fa-link"></i></a>Jan-Bart de Vreede and Stu West finish their terms on the Board of Trustees</h2>
             <p>Jan-Bart de Vreede and Stu West leave the Board of Trustees as their terms expire.</p>
           </div>
         </div>
@@ -867,7 +867,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-05">January 5, 2016</time></span>
-            <h2>Kelly Battles and Arnnon Geshuri appointed to Board of Trustees</h2>
+            <h2><a id="51" href="#51"><i class="fa fa-link"></i></a>Kelly Battles and Arnnon Geshuri appointed to Board of Trustees</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Kelly_Battles_-_January_2016_by_Myleen_Hollero.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/51/Kelly_Battles_-_January_2016_by_Myleen_Hollero.jpg/320px-Kelly_Battles_-_January_2016_by_Myleen_Hollero.jpg" alt="Portrait of Kelly Battles" />
@@ -893,7 +893,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-05">January 5, 2016</time></span>
-            <h2>Boryana Dineva replies to an email on <i>Wikimedia-l</i> about retention</h2>
+            <h2><a id="52" href="#52"><i class="fa fa-link"></i></a>Boryana Dineva replies to an email on <i>Wikimedia-l</i> about retention</h2>
             <p>After a community member expresses concern over a high level of staff turnover at the Wikimedia Foundation, Vice President of Human Resources Boryana Dineva <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/080734.html">replies</a>, "The HR team definitely keeps an eye on turnover on a regular basis. One of the first things I did when I started (approximately 3 months ago) is a stats health check including turnover trends, org demographics, compensation practices, recruiting stats, etc." She describes analysis her team performs on turnover and compares to market trends, and discusses regular surveys on staff engagement. She is later <a href="https://meta.wikimedia.org/wiki/User_talk:LilaTretikov_%28WMF%29#FYI:_Follow-up_question_from_the_metrics_meeting_today">criticized</a> for not disclosing the level of discontent with senior management that was reflected in the most recent employee survey.</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/080728.html">Thread about retention on <i>Wikimedia-l</i></a></li>
@@ -909,7 +909,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-06">January 6, 2016</time></span>
-            <h2>Wikimedia Foundation announces grant from the Knight Foundation</h2>
+            <h2><a id="53" href="#53"><i class="fa fa-link"></i></a>Wikimedia Foundation announces grant from the Knight Foundation</h2>
             <p>The Wikimedia Foundation announces a $250,000 grant from the Knight Foundation to "launch a new project to explore ways to make the search and discovery of high quality, trustworthy information on Wikipedia more accessible and open." This announcement comes two months after the Board of Trustees vote to accept the grant.</p>
             <ul>
               <li><a href="https://blog.wikimedia.org/2016/01/06/explore-new-ways-to-search-and-discover/">Wikimedia blog: Wikimedia Foundation to explore new ways to search and discover reliable, relevant, free information with $250,000 from Knight Foundation</a></li>
@@ -923,7 +923,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-07">January 7, 2016</time></span>
-            <h2>Community members discuss Arnnon Geshuri's role in the High-Tech Employee Antitrust Litigation</h2>
+            <h2><a id="54" href="#54"><i class="fa fa-link"></i></a>Community members discuss Arnnon Geshuri's role in the High-Tech Employee Antitrust Litigation</h2>
             <p>Days after Arnnon Geshuri's appointment to the board, a community member <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/080820.html">notes in an email to <i>Wikimedia-l</i></a> that Geshuri was involved in the <a href="https://en.wikipedia.org/wiki/High-Tech_Employee_Antitrust_Litigation">High-Tech Employee Antitrust Litigation</a>. Geshuri, then the director of staffing at Google, <a href="http://www.theverge.com/2012/1/27/2753701/no-poach-scandal-unredacted-steve-jobs-eric-schmidt-paul-otellini">received a complaint</a> from Steve Jobs that a Google recruiter had attempted to poach an Apple employee. Geshuri responded to say that the recruiter "should not have [contacted the employee] and will be terminated within the hour," and that "we will be very careful to make sure this does not happen again." Litigation on the issue later ended in a settlement involving both Google and Apple, amounting to $415 million.</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/High-Tech_Employee_Antitrust_Litigation">High-Tech Employee Antitrust Litigation</a></li>
@@ -938,7 +938,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-07">January 7&ndash;8, 2016</time></span>
-            <h2>Wikimedia Foundation Staff All-Hands meeting</h2>
+            <h2><a id="55" href="#55"><i class="fa fa-link"></i></a>Wikimedia Foundation Staff All-Hands meeting</h2>
             <p>The WMF Staff All-Hands meeting is held. This meeting is organized by staff members outside of Human Resources, which is unusual.</p>
           </div>
         </div>  
@@ -949,7 +949,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-11">January 11, 2016</time></span>
-            <h2>The Wikimedia Foundation begins a new strategy consultation</h2>
+            <h2><a id="56" href="#56"><i class="fa fa-link"></i></a>The Wikimedia Foundation begins a new strategy consultation</h2>
             <p>With the February 2015 strategy consultation abandoned, <a href="https://meta.wikimedia.org/wiki/2016_Strategy/FAQ">a new one</a> is opened. The staff managing the effort emphasize that "We also need to finalize the Foundation's strategy quickly, so that we can meet our 2016 Annual Plan deadlines and align our team and department strategies with the overall strategy."</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/2016_Strategy/FAQ">Meta: 2016 Strategy/FAQ</a></li>
@@ -963,7 +963,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-14">January 14, 2016</time></span>
-            <h2>Frances Hocutt speaks up about staff engagement survey at the Metrics meeting</h2>
+            <h2><a id="57" href="#57"><i class="fa fa-link"></i></a>Frances Hocutt speaks up about staff engagement survey at the Metrics meeting</h2>
             <p>At the January Metrics meeting, software developer Frances Hocutt speaks up to ask why the high level of discontent with senior leadership reflected in the staff engagement survey is not being discussed. Senior Research Scientist Aaron Halfaker <a href="https://meta.wikimedia.org/wiki/Talk:WMF_Metrics_and_activities_meetings/2016-01#Follow-up_from_live_question_re._engagement_survey">follows up</a> on the Metrics meeting talk page and <a href="https://meta.wikimedia.org/wiki/User_talk:LilaTretikov_%28WMF%29#FYI:_Follow-up_question_from_the_metrics_meeting_today">posts on Lila Tretikov's talk page</a> to attempt to get a response to the question. Tretikov says she will ask to follow up, but the question goes unanswered.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/2016_Strategy/FAQ">Meta: 2016 Strategy/FAQ</a></li>
@@ -979,7 +979,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-20">January 20, 2016</time></span>
-            <h2>Request for comment filed for a vote of no confidence in Arnnon Geshuri</h2>
+            <h2><a id="58" href="#58"><i class="fa fa-link"></i></a>Request for comment filed for a vote of no confidence in Arnnon Geshuri</h2>
             <p>A request for comment is opened on Meta, proposing "In the best interests of the Wikimedia Foundation, Arnnon Geshuri must be removed from his appointment as a trustee of the Wikimedia Foundation Board." Board member Guy Kawasaki is notably the first to oppose the vote. The vote eventually receives 292 votes supporting the no confidence proposal and 22 opposing. The issue receives broad coverage in the mainstream media.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Requests_for_comment/Vote_of_no_confidence_on_Arnnon_Geshuri">Meta request for comment: Vote of no confidence on Arnnon Geshuri</a></li>
@@ -997,7 +997,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-25">January 25, 2016</time></span>
-            <h2>Jimmy Wales describes James Heilman's statements as "utter fucking bullshit"</h2>
+            <h2><a id="59" href="#59"><i class="fa fa-link"></i></a>Jimmy Wales describes James Heilman's statements as "utter fucking bullshit"</h2>
             <p>In a reply on Jimmy Wales' own talk page, Wales writes, "[Questions asking why Heilman was removed from the board have] been answered clearly.  As a quick review - my vote to remove him was because of a pattern of behavior and actions that I viewed as violating the trust and values of the community.  One example emerged clearly after he was removed - he made a false claim about why he was removed, and I got a unanimous statement from every board member involved that it was false.  The community deserves better than that. James has made a lot of noise about why he was dismissed which is utter and complete bullshit.  He wrote a nice piece for the Signpost about transparency which implied that the board got rid of him for wanting more transparency.  Utter fucking bullshit."</p>
             <ul>
               <li><a href="https://en.wikipedia.org/w/index.php?title=User_talk:Jimbo_Wales&oldid=701673700#James_Heilman">Jimmy Wales' comment on his Wikipedia talk page</a></li>
@@ -1011,7 +1011,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-26">January 26, 2016</time></span>
-            <h2>Arnnon Geshuri emails <i>Wikimedia-l</i> to say he intends to stay on the Board of Trustees</h2>
+            <h2><a id="60" href="#60"><i class="fa fa-link"></i></a>Arnnon Geshuri emails <i>Wikimedia-l</i> to say he intends to stay on the Board of Trustees</h2>
             <p>Arnnon Geshuri <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/081431.html">sends an email</a> to <i>Wikimedia-l</i> acknowledging the complaints that have been made about him. In his message, he states, "I know I have a longer journey than most new Board members to prove to the community and WMF alumni that they can put their trust in me." His pledges to work through the issues are later criticized by a community member, who <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/081445.html">writes</a>, "What you describe as an *inspirational* experience, I see as an extremely painful event to watch as it damages the Wikimedia Foundation and the wikimedia movement."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/081431.html">Email from Arnnon Geshuri to <i>Wikimedia-l</i>: Message from Arnnon Geshuri to the Wikimedia Community</a></li>
@@ -1026,7 +1026,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-27">January 27, 2016</time></span>
-            <h2>Arnnon Geshuri resigns from the Board of Trustees</h2>
+            <h2><a id="61" href="#61"><i class="fa fa-link"></i></a>Arnnon Geshuri resigns from the Board of Trustees</h2>
             <p>The day after Geshuri emails <i>Wikimedia-l</i> indicating that he intends to remain on the Board of Trustees, board chair Patricio Lorente and vice chair Alice Wiegand <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/081484.html">send an email</a> to report that Geshuri has decided to step down. In the email, they say, "To paraphrase his words, he doesn't want to be a distraction for the important discussions that the community and the Foundation need to face in the times to come."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/081484.html">Email from Patricio Lorente and Alice Wiegand to <i>Wikimedia-l</i>: Changes in the Board</a></li>
@@ -1041,7 +1041,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-28">January 28, 2016</time></span>
-            <h2>Pine posts on Lila Tretikov's talk page about employee intimidation</h2>
+            <h2><a id="62" href="#62"><i class="fa fa-link"></i></a>Pine posts on Lila Tretikov's talk page about employee intimidation</h2>
             <p><a href="https://meta.wikimedia.org/wiki/User:Pine">User:Pine</a> <a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15289730#Employee_communications">begins a conversation</a> on Lila Tretikov's Meta talk page about rumors that Wikimedia Foundation employees are being intimidated into silence.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15289730#Employee_communications">Meta post by Pine: User talk:LilaTretikov (WMF)#Employee communications</a></li>
@@ -1055,7 +1055,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-29">January 29, 2016</time></span>
-            <h2>Lila Tretikov replies to thread about employee intimidation</h2>
+            <h2><a id="63" href="#63"><i class="fa fa-link"></i></a>Lila Tretikov replies to thread about employee intimidation</h2>
             <p>Lila Tretikov <a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15293307#Employee_communications">responds</a> to a thread containing concerns about employee intimidation at the Wikimedia Foundation. In her reply, she says, "Hi Pine, retaliation is strictly prohibited by WMF policy and will not be tolerated. A healthy discourse is important in any organization, especially within our movement which values free speech. We support feedback in our office. I ask anyone who believes they are experiencing retaliation to report it to myself, HR, or Legal. Allegations of retaliation will be investigated and we will take action."</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15293307#Employee_communications">Meta post by Lila Tretikov: User talk:LilaTretikov (WMF)#Employee communications</a></li>
@@ -1069,7 +1069,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-29">January 29, 2016</time></span>
-            <h2>Lila Tretikov posts "Some background on the KE grant" on her Meta talk page</h2>
+            <h2><a id="64" href="#64"><i class="fa fa-link"></i></a>Lila Tretikov posts "Some background on the KE grant" on her Meta talk page</h2>
             <p>In response to questions about the Knight Foundation grant, Lila Tretikov posts <a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15294045#Some_background_on_the_KE_grant">an explanation</a> on her Meta talk page. It opens with, "As some of you know, I have been making concerted efforts to engage deeper on-wikis and to provide more insights into my thought process. As a demonstration of this commitment, I would like to share my thoughts on the Knight Foundation grant which has been called out for clarification." She goes on to take responsibility for not discussing the grant with the community sooner, and says, "Quite honestly, I really wish I could start this discussion over in a more collaborative way, knowing what I know today." In a later section, she explains that she cannot share the full content of the Knight Foundation grant paperwork because of "donor privacy."
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15294045#Some_background_on_the_KE_grant">Meta: User talk: LilaTretikov(WMF)#Some background on the KE grant</a></li>
@@ -1083,7 +1083,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-30">January 30, 2016</time></span>
-            <h2>Lisa Martinez leaves</h2>
+            <h2><a id="65" href="#65"><i class="fa fa-link"></i></a>Lisa Martinez leaves</h2>
             <p>Lisa Martinez, Executive Assistant to the Executive Director and Board Liason, leaves the Wikimedia Foundation after two and a half years of employment.</p>
           </div>
         </div>
@@ -1094,7 +1094,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-01-31">January 31, 2016</time></span>
-            <h2>Mar&iacute;a Sefidari rejoins the Board of Trustees</h2>
+            <h2><a id="66" href="#66"><i class="fa fa-link"></i></a>Mar&iacute;a Sefidari rejoins the Board of Trustees</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:María_Sefidari.JPG">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Mar%C3%ADa_Sefidari.JPG/320px-Mar%C3%ADa_Sefidari.JPG" alt="Portrait of Mar&iacute;a Sefidari" />
@@ -1114,7 +1114,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-1">February 1, 2016</time></span>
-            <h2>Jaime Villagomez joins as Chief Financial Officer</h2>
+            <h2><a id="67" href="#67"><i class="fa fa-link"></i></a>Jaime Villagomez joins as Chief Financial Officer</h2>
             <p>Jaime Villagomez joins the Wikimedia Foundation as the Chief Financial Officer. Before coming to the WMF, he worked as the CFO at two start-ups: AnyCOMM, a "smart cities" company, and Karum Group, a credit service company.</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/080987.html">Email from Lila Tretikov to <i>Wikimedia-l</i>: Fwd: Introducing Jaime Villagomez as our Chief Financial Officer</a></li>
@@ -1128,7 +1128,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-01">February 1, 2016</time></span>
-            <h2>Frances Hocutt replies to thread about employee intimidation</h2>
+            <h2><a id="68" href="#68"><i class="fa fa-link"></i></a>Frances Hocutt replies to thread about employee intimidation</h2>
             <p>Frances Hocutt, a software developer for the Wikimedia Foundation, <a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15301530#Employee_communications">responds</a> to a thread containing concerns about employee intimidation at the Wikimedia Foundation. She says, "I have taken great care to speak with civility during these months of conflict, particularly when I have spoken in public. I have also expressed my concerns about the potential for retaliation to my manager and to HR. I have been repeatedly assured that <b>I</b> have nothing to worry about due to the care I take with my words, but the specific standards that are being used to define 'aggressive', 'unprofessional', and 'uncivil' are still unclear to me. I hear my colleagues' concerns and see some of them being censured for speaking in ways that I have found sharply critical but still fundamentally honest and civil, and I worry that someday I will be the one who is suddenly found to have stepped over lines which were previously invisible or unspoken. I fear that even making this reply with my volunteer account will be considered 'unprofessional': it is both critical and public, and no clarification has been given yet on the question of what constitutes 'professional' usage of our staff and volunteer accounts." Her edit summary is, "reply to Pine: I'm still afraid." There has been no response from Tretikov.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/w/index.php?title=User_talk:LilaTretikov_(WMF)&oldid=15301530#Employee_communications">Meta post by Frances Hocutt: User talk:LilaTretikov (WMF)#Employee communications</a></li>
@@ -1142,7 +1142,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-06">February 6, 2016</time></span>
-            <h2>Community member raises concerns about Boryana Dineva</h2>
+            <h2><a id="69" href="#69"><i class="fa fa-link"></i></a>Community member raises concerns about Boryana Dineva</h2>
             <p>On January 11, Lila Tretikov had sent <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-January/080987.html">an email</a> to <i>Wikimedia-l</i> thanking Amy Elder and Boryana Dineva for managing the recruiting process that resulted in Arnnon Geshuri's appointment. On February 6, Ruslan Takayev sends <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/081677.html">an email</a> including, "Are we any closer to having public comments from the BoT on how the Arrnon debacle was able to occur? I am especially interested in how Boryana fits in with this. Given Boryana's shared history t Telsa with Arnnon, she would surely have known about Arnnon's past at Google, but it would appear this past was never mentioned in the presentation to the board by her. At best this could be seen as an attempt to secure "jobs for the boys"; at worst it can be seen as incompetence on the part of Boryana." There has been no response.</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/081677.html">Ruslan Takayev's email to <i>Wikimedia-l</i>: Changes in the Board</a></li>
@@ -1157,7 +1157,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-08">February 8, 2016</time></span>
-            <h2>Luis Villa leaves</h2>
+            <h2><a id="70" href="#70"><i class="fa fa-link"></i></a>Luis Villa leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Villa,_Luis_4.11.2013.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Villa%2C_Luis_4.11.2013.jpg/320px-Villa%2C_Luis_4.11.2013.jpg" alt="Staff portrait of Luis Villa" />
@@ -1179,7 +1179,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-09">February 9, 2016</time></span>
-            <h2>Anna Koval leaves</h2>
+            <h2><a id="71" href="#71"><i class="fa fa-link"></i></a>Anna Koval leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Koval,_Anna_Aug_2013.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8f/Koval%2C_Anna_Aug_2013.jpg/320px-Koval%2C_Anna_Aug_2013.jpg" alt="Staff portrait of Anna Koval" />
@@ -1199,7 +1199,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-09">February 9, 2016</time></span>
-            <h2>Boryana Dineva goes on leave of absence</h2>
+            <h2><a id="72" href="#72"><i class="fa fa-link"></i></a>Boryana Dineva goes on leave of absence</h2>
             <p>Boryana Dineva, Vice President of Human Resources, goes on leave of absence after joining the Wikimedia Foundation five months earlier.</p>
           </div>
         </div>
@@ -1210,7 +1210,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-11">February 11, 2016</time></span>
-            <h2>Jimmy Wales posts on his talk page that the Wikimedia Foundation will not be creating a general search engine</h2>
+            <h2><a id="73" href="#73"><i class="fa fa-link"></i></a>Jimmy Wales posts on his talk page that the Wikimedia Foundation will not be creating a general search engine</h2>
             <p>Jimmy Wales <a href="https://en.wikipedia.org/w/index.php?title=User_talk:Jimbo_Wales&diff=prev&oldid=704421946">posts</a> on his talk page: "To make this very clear: no one in top positions has proposed or is proposing that WMF should get into the general 'searching' or to try to 'be google'. It's an interesting hypothetical which has not been part of any serious strategy proposal, nor even discussed at the board level, nor proposed to the board by staff, nor a part of any grant, etc. It's a total lie."</p>
             <ul>
               <li><a href="https://en.wikipedia.org/w/index.php?title=User_talk:Jimbo_Wales&diff=prev&oldid=704421946">Jimmy Wales' talk page post</a></li>
@@ -1225,7 +1225,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-11">February 11, 2016</time></span>
-            <h2>Knight Foundation grant approval published</h2>
+            <h2><a id="74" href="#74"><i class="fa fa-link"></i></a>Knight Foundation grant approval published</h2>
             <p>Juliet Barbara, Senior Communications Manager, publishes the PDF of the September 18 Knowledge Engine grant approval document publicly on the Wikimedia Foundation wiki.</p>
             <ul>
               <li><a href="https://wikimediafoundation.org/wiki/File:Knowledge_engine_grant_agreement.pdf">Knowledge Engine grant agreement</a></li>
@@ -1240,7 +1240,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-12">February 12, 2016</time></span>
-            <h2>James Heilman states that cost estimates provided to the board for the Knowledge Engine were in the "10s of millions range and were still likely conservative"</h2>
+            <h2><a id="75" href="#75"><i class="fa fa-link"></i></a>James Heilman states that cost estimates provided to the board for the Knowledge Engine were in the "10s of millions range and were still likely conservative"</h2>
             <p>James Heilman writes on Facebook, "there are more complete estimates of costs that both you and I saw that were for all four stages of this project. These estimates were in the 10s of millions range and were still likely conservative. Yes I agree that a global search engine is going to cost more than 2.5M and cost estimates were well above that." He later mentions $32 million as a proposed amount.</p>
             <ul>
               <li><a href="https://www.facebook.com/groups/wikipediaweekly/permalink/956660811048417/?comment_id=956770694370762&reply_comment_id=956932567687908&comment_tracking=%7B%22tn%22%3A%22R7%22%7D">James Heilman's comment</a></li>
@@ -1255,7 +1255,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-12">February 12, 2016</time></span>
-            <h2>Siko Bouterse leaves</h2>
+            <h2><a id="76" href="#76"><i class="fa fa-link"></i></a>Siko Bouterse leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Siko_Bouterse-8.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Siko_Bouterse-8.jpg/320px-Siko_Bouterse-8.jpg" alt="Staff portrait of Siko Bouterse" />
@@ -1276,7 +1276,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-15">February 15, 2016</time></span>
-            <h2><i>Signpost</i> reveals that the Wikimedia Foundation initially requested $6 million from the Knight Foundation</h2>
+            <h2><a id="77" href="#77"><i class="fa fa-link"></i></a><i>Signpost</i> reveals that the Wikimedia Foundation initially requested $6 million from the Knight Foundation</h2>
             <p>The <i>Signpost</i> examines internal documents to conclude that the Wikimedia Foundation initially requested the Knight Foundation provide a $6 million grant to fund the first stage of the project over three years. The grant was finalized at $250,000 for a year of development. The documents also state that "the remaining initial support will come from the Wikimedia Foundation's general fund or from additional restricted grants."</p>
             <ul>
               <li><a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-10/In_focus"><i>Signpost</i>: An in-depth look at the newly revealed documents</a></li>
@@ -1291,7 +1291,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-15">February 15, 2016</time></span>
-            <h2>Jimmy Wales denies that the Knowledge Engine is a Google competitor</h2>
+            <h2><a id="78" href="#78"><i class="fa fa-link"></i></a>Jimmy Wales denies that the Knowledge Engine is a Google competitor</h2>
             <p>Jimmy Wales posts on his user talk page suggesting that people "[read] the actual grant agreement" and stating, "Media reports and trolling suggesting that this is some kind of broad google competitor remain completely and utterly false."</p>
             <ul>
               <li><a href="https://en.wikipedia.org/w/index.php?title=User_talk%3AJimbo_Wales&type=revision&diff=705106912&oldid=705099773">Jimmy Wales' talk page post</a></li>
@@ -1306,7 +1306,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-16">February 16, 2016</time></span>
-            <h2>Wes Moran and Lila Tretikov publish a post on the Wikimedia blog titled "Clarity on the future of Wikimedia search"</h2>
+            <h2><a id="79" href="#79"><i class="fa fa-link"></i></a>Wes Moran and Lila Tretikov publish a post on the Wikimedia blog titled "Clarity on the future of Wikimedia search"</h2>
             <p>Wes Moran and Lila Tretikov release a blog post describing the current state of search on Wikimedia projects, the Knight Foundation grant, and plans for search engines. The post seems targeted at recent press attention describing the project as a Google competitor. The post states, "What are we not doing? We're not building a global crawler search engine. We're not building another, separate Wikimedia project.... Despite headlines, we are not trying to compete with other platforms, including Google."</p>
             <ul>
               <li><a href="https://blog.wikimedia.org/2016/02/16/wikimedia-search-future/">Wikimedia blog: Clarity on the future of Wikimedia search</a></li>
@@ -1320,7 +1320,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-16">February 16, 2016</time></span>
-            <h2>Brion Vibber asks "why the secrecy and stonewalling?" on a comment on the Moran&ndash;Tretikov post</h2>
+            <h2><a id="80" href="#80"><i class="fa fa-link"></i></a>Brion Vibber asks "why the secrecy and stonewalling?" on a comment on the Moran&ndash;Tretikov post</h2>
             <p>Brion Vibber, Lead Software Architect for the Wikimedia Foundation, writes a comment on Moran and Tretikov's blog post: "I know that former VP of Engineering Damon Sicore secretly shopped around grandiose ideas about a free knowledge search engine, which eventually evolved into the reorg creating the Discovery team. From leaked documents, we know at least some of those grandiose plans went into the early drafts of the Knight Foundation grant request, which eventually became a smallish grant to support Wikipedia's search capabilities. What we don't know is to what degree Executive Director Lila Tretikov was supporting the secretive "compete with Google" plan without putting it into WMF's public plans. It seems this would all be a simple case of "yes, there was some talk and we decided against it", so why the secrecy and stonewalling?"</p>
             <ul>
               <li><a href="https://blog.wikimedia.org/2016/02/16/wikimedia-search-future/#comment-25092">Vibber's comment on the "Clarity on the future of Wikimedia search" post</a></li>
@@ -1334,7 +1334,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-17">February 17, 2016</time></span>
-            <h2>Frances Hocutt goes on leave</h2>
+            <h2><a id="81" href="#81"><i class="fa fa-link"></i></a>Frances Hocutt goes on leave</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Hocutt,_Frances_March_2015.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/0/01/Hocutt%2C_Frances_March_2015.jpg" alt="Staff portrait of Frances Hocutt" />
@@ -1354,7 +1354,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-17">February 17, 2016</time></span>
-            <h2>Steve Scheier says he is no longer working with Lila Tretikov</h2>
+            <h2><a id="82" href="#82"><i class="fa fa-link"></i></a>Steve Scheier says he is no longer working with Lila Tretikov</h2>
             <p>Steve Scheier, brought on on November 22, 2015 as a coach to Lila Tretikov to help with "leadership challenges," emails Wikimedia Foundation staff to clarify that he is no longer coaching Tretikov or working on projects with the Wikimedia Foundation. This directly refutes a statement from Tretikov that they are still working together.</p>
           </div>
         </div>
@@ -1365,7 +1365,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-17">February 17, 2016</time></span>
-            <h2>Max Semenik clarifies whether Knowledge Engine is a search engine</h2>
+            <h2><a id="83" href="#83"><i class="fa fa-link"></i></a>Max Semenik clarifies whether Knowledge Engine is a search engine</h2>
             <p>Max Semenik, software developer on the Search and Discovery team, <a href="https://blog.wikimedia.org/2016/02/16/wikimedia-search-future/#comment-25102">comments</a> on the Moran&ndash;Tretikov post about whether the Knowledge Engine is a search engine, and on how the proposal has changed. He says, "Yes, there were plans of making an internet search engine. I don’t understand why we’re still trying to avoid giving a direct answer about it.... The whole project didn’t live long and was ditched soon after the Search team was created, after FY15/16 budget was finalized, and it did not have the money allocated for such work.... I don’t think anybody but the certain champion of the project has considered competing with Google with any degree of seriousness. The scrapping was finalized in summer, after said champion and WMF parted ways. However, ideas and wording from that search engine plan made their way to numerous discovery team documents and were never fully expelled."</p>
             <ul>
               <li><a href="https://blog.wikimedia.org/2016/02/16/wikimedia-search-future/#comment-25102">Max Semenik's comment on the Moran&ndash;Tretikov Wikimedia blog post</a></li>
@@ -1379,7 +1379,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-18">February 18, 2016</time></span>
-            <h2>Ido Ivri sends "An Open Letter to Wikimedia Foundation BoT" email to <i>Wikimedia-l</i></h2>
+            <h2><a id="84" href="#84"><i class="fa fa-link"></i></a>Ido Ivri sends "An Open Letter to Wikimedia Foundation BoT" email to <i>Wikimedia-l</i></h2>
             <p>Ido Ivri, a member of the Wikimedia Israel board, writes an <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/081966.html">open letter to the Board of Trustees</a> and sends it to <i>Wikimedia-l</i>. He details his concerns with "deep, strategic change" in the Wikimedia Foundation that is not accompanied with transparency, honesty, or accountability; "concealment (rather than openness) as a default"; lack of communication and consultation with the community; and lack of communication and trust from and with the Board of Trustees. He adds, "If any APG-receiving affiliate conducted itself in such a non transparent, dishonest manner and with lack of clear, timely communication with its community and stakeholders, it would get seriously reprimanded by the Foundation."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/081966.html">Email from Ido Ivri to <i>Wikimedia-l</i>: An Open Letter to Wikimedia Foundation BoT</a></li>
@@ -1393,7 +1393,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-19">February 19, 2016</time></span>
-            <h2><i>The Wikipedian</i> publishes "Search and Destroy: The Knowledge Engine and the Undoing of Lila Tretikov"</h2>
+            <h2><a id="85" href="#85"><i class="fa fa-link"></i></a><i>The Wikipedian</i> publishes "Search and Destroy: The Knowledge Engine and the Undoing of Lila Tretikov"</h2>
             <p><i>The Wikipedian</i>, a blog about Wikipedia written by <a href="https://en.wikipedia.org/wiki/User:WWB">William Beutler</a>, publishes "<a href="http://thewikipedian.net/2016/02/19/knowledge-engine-lila-tretikov/">Search and Destroy: The Knowledge Engine and the Undoing of Lila Tretikov</a>". The article is also <a href="https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_Signpost/2016-02-17/Special_report">published</a> in the <i>Signpost</i>. It opens with, "The Wikimedia Foundation is in open revolt." and continues to detail staff departures, dissatisfaction with WMF senior leadership, concerns about the Knowledge Engine project, and other unrest. It concludes, "For the sake of Wikipedia’s future, the Wikimedia Foundation needs new leadership. Lila Tretikov must resign, or she must be replaced." The article received many comments in both venues.</p>
             <ul>
               <li><a href="http://thewikipedian.net/2016/02/19/knowledge-engine-lila-tretikov/"><i>The Wikipedian</i>: "Search and Destroy: The Knowledge Engine and the Undoing of Lila Tretikov"</a></li>
@@ -1408,7 +1408,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-22">February 22, 2016</time></span>
-            <h2>Lila Tretikov sends email to <i>Wikimedia-l</i></h2>
+            <h2><a id="86" href="#86"><i class="fa fa-link"></i></a>Lila Tretikov sends email to <i>Wikimedia-l</i></h2>
             <p>Lila Tretikov sends an email to <i>Wikimedia-l</i> titled <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/082145.html">Why we changed</a>. In this email, she states that, "After 15 years since the birth of Wikipedia, the WMF needs to rethink itself to ensure our editor work expands into the next decade.... The choice in front the WMF is that of our core identity.... We could either fully focus on building our content and educational programs. Or we can get great at technology as the force multiplier for our movement. I believe the the former belongs to our volunteers and affiliates and that the role of the WMF is in providing global support and coordination of this work. I believe in -- and the board hired me to -- focus on the latter. To transform our organization into a high-tech NGO, focused on the needs of our editors and readers and rapidly moving to update our aged technology to support those needs. To this end we have made many significant changes.... Many at the WMF and in our community believe that we should not be a high-tech organization. I believe we should." She includes in the email a list of accomplishments the Wikimedia Foundation has made. She ends the email by stating, "The world is not standing still. It will not wait for us to finish our internal battles and struggles. Time is our most precious commodity."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/082145.html">Lila Tretikov's email to <i>Wikimedia-l</i>: Why we changed</a></li>
@@ -1422,7 +1422,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-22">February 22, 2016</time></span>
-            <h2>Staff members reply to Lila Tretikov's <i>Wikimedia-l</i> email</h2>
+            <h2><a id="87" href="#87"><i class="fa fa-link"></i></a>Staff members reply to Lila Tretikov's <i>Wikimedia-l</i> email</h2>
             <p>WMF Lead Software Architect Brion Vibber includes, "First, many staff members feel that the accomplishments you claim under "we" are not attributable to you. Complaints about lack of strategy and confusing management have come from all levels of the staff; the implication that people who failed to be promoted might be behind discontent seems not to hold water.... If your contention is that tech supports you as a silent majority, I have strong doubts that this is the case."</p>
 
             <p>Development Outreach Manager Anna Stillwell and Research Analyst Oliver Keyes, reply to state their agreement with Vibber.</p>
@@ -1448,7 +1448,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-22">February 22, 2016</time></span>
-            <h2>Rumors of a board meeting to discuss Lila Tretikov's position as Executive Director</h2>
+            <h2><a id="88" href="#88"><i class="fa fa-link"></i></a>Rumors of a board meeting to discuss Lila Tretikov's position as Executive Director</h2>
             <p>In a <a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/082215.html">response</a> to a <i>Wikimedia-l</i> post questioning when the Board of Trustees will meet to discuss Lila Tretikov's role, Brion Vibber writes, "Rumor mill says they're meeting again on the subject at 9am pacific today."</p>
             <ul>
               <li><a href="https://lists.wikimedia.org/pipermail/wikimedia-l/2016-February/082215.html">Brion Vibber's email to <i>Wikimedia-l</i></a></li>
@@ -1462,7 +1462,7 @@
           </div>
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2016-02-23">February 23, 2016</time></span>
-            <h2>Oliver Keyes leaves</h2>
+            <h2><a id="89" href="#89"><i class="fa fa-link"></i></a>Oliver Keyes leaves</h2>
             <div class="captioned-image image-right landscape">
               <a href="https://commons.wikimedia.org/wiki/File:Keyes,_Oliver_January_2016.jpg">
                 <img src="https://upload.wikimedia.org/wikipedia/commons/e/e5/Keyes%2C_Oliver_January_2016.jpg" alt="Staff portrait of Oliver Keyes" />


### PR DESCRIPTION
This is an attempt to fix #15.

You can see it live here, with this demo link to the "Letter to Wikimedia Foundation: Superprotect and Media Viewer" heading:

http://toolness.github.io/wikimedia-timeline/#3

Note that while this diff is a bit of a doozy, I was actually quite lazy and wrote a simple Python script to do most of the work for me:

``` python
import sys
import re

lines = open('index.html', 'r').readlines()

i = 0

for line in lines:
    if '<h2>' in line:
        i += 1
        m = re.search(r'^(\s*)\<h2\>(.+)\<\/h2\>$', line)
        line = '%s<h2><a id="%d" href="#%d"><i class="fa fa-link"></i></a>%s</h2>\n' % (
            m.group(1),
            i,
            i,
            m.group(2)
        )
    sys.stdout.write(line)
```

In other words, this wasn't actually a lot of work for me to do, so if you think that there's a better way to present hyperlinks here, let me know!
