### PR TITLE
fixed a visual typo - the center line wasn't centered on the icons

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -57,7 +57,7 @@ footer.page-footer a {
   content: '';
   position: absolute;
   top: 0;
-  left: 50%;
+  left: 50.2%;
   height: 100%;
   width: 4px;
   background: #ccc;


### PR DESCRIPTION
The icons weren't quite centered on the timeline. It was really subtle, I only noticed it because the plus in the green icons didn't line up with the center line, but once I did it was super annoying. I'm not sure why setting the line and the icons at 50% didn't line them up, but I think it's because the line is drawn as a border so it centers on an edge of the line instead of the center. Whatever the reason, I shifted it slightly to the right and now everything lines up visually (for me at least).
