### PR TITLE
Fix spelling of "Vrandečić".

### DIFF
--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
           <div class="timeline-description">
             <span class="timestamp"><time datetime="2015-06-05">June 5, 2015</time></span>
             <h2><a id="bot-results" href="#bot-results"><i class="fa fa-link"></i></a>2015 Wikimedia Foundation Board of Trustees election results announced</h2>
-            <p>Dariusz Jemielniak (<a href="https://meta.wikimedia.org/wiki/User:Pundit">User:Pundit</a>), James Heilman (<a href="https://meta.wikimedia.org/wiki/User:Doc_James">User:Doc James</a>), and Denny Vrande&#269;i;&#263; (<a href="https://meta.wikimedia.org/wiki/User:Denny">User:Denny</a>) are elected to the three two-year-long community seats on the Wikimedia Foundation's <a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation_Board_of_Trustees">Board of Trustees</a>.</p>
+            <p>Dariusz Jemielniak (<a href="https://meta.wikimedia.org/wiki/User:Pundit">User:Pundit</a>), James Heilman (<a href="https://meta.wikimedia.org/wiki/User:Doc_James">User:Doc James</a>), and Denny Vrande&#269;i&#263; (<a href="https://meta.wikimedia.org/wiki/User:Denny">User:Denny</a>) are elected to the three two-year-long community seats on the Wikimedia Foundation's <a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation_Board_of_Trustees">Board of Trustees</a>.</p>
             <ul>
               <li><a href="https://meta.wikimedia.org/wiki/Wikimedia_Foundation_elections/Board_elections/2015">2015 elections to the Board of Trustees</a></li>
             </ul>


### PR DESCRIPTION
There was an errant ";" in the surname.
